### PR TITLE
bump version to 3.19 for mongo URI fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "async": "~1.2.1",
     "connect-mongo": "~0.8.1",
     "dotenv": "1.1.0",
-    "keystone": "~0.3.11",
+    "keystone": "~0.3.19",
     "underscore": "~1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Related https://github.com/keystonejs/keystone/issues/3009

we should also see if the starter should have a fixed npm version due to heroku's behavior 